### PR TITLE
Clear() method should not delete keys in other references to underlying map.

### DIFF
--- a/httpcontext.go
+++ b/httpcontext.go
@@ -58,11 +58,8 @@ func Delete(req *http.Request, key interface{}) {
 
 // Clear clears all stored values from a request’s context.
 func Clear(req *http.Request) {
-	crc := getContextReadCloser(req)
-	ctx := crc.Context()
-	for key := range ctx {
-		delete(ctx, key)
-	}
+	crc := getContextReadCloser(req).(*contextReadCloser)
+	crc.context = map[interface{}]interface{}{}
 }
 
 // ContextReadCloser augments the io.ReadCloser interface

--- a/httpcontext_test.go
+++ b/httpcontext_test.go
@@ -7,6 +7,7 @@ package httpcontext
 import (
 	"net/http"
 	"testing"
+
 	"github.com/nbio/st"
 )
 
@@ -47,7 +48,7 @@ func TestContext(t *testing.T) {
 	value, ok = GetOk(req, "nil value")
 	st.Expect(t, value, nil)
 	st.Expect(t, ok, true)
-	
+
 	// GetString()
 	Set(req, "int value", 13)
 	Set(req, "string value", "hello")
@@ -74,6 +75,10 @@ func TestContext(t *testing.T) {
 	st.Expect(t, len(crc.Context()), 3)
 
 	// Clear()
+	Set(req, key1, true)
+	values = GetAll(req)
 	Clear(req)
 	st.Expect(t, len(crc.Context()), 0)
+	val, _ := values[key1].(bool)
+	st.Expect(t, val, true) // Clear shouldn't delete values grabbed before
 }


### PR DESCRIPTION
I really like idea of using http.Request.Body to store context data :)